### PR TITLE
updates get_image_model to wagtail 10

### DIFF
--- a/src/wagtail_factories/factories.py
+++ b/src/wagtail_factories/factories.py
@@ -2,7 +2,7 @@ import factory
 from django.utils.text import slugify
 from factory.utils import extract_dict
 from wagtail.wagtailcore.models import Collection, Page, Site
-from wagtail.wagtailimages.models import get_image_model
+from wagtail.wagtailimages import get_image_model
 
 __all__ = [
     'CollectionFactory',


### PR DESCRIPTION
They moved it away from the models.py to \_\_init\_\_.py