### PR TITLE
Bump versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,50 +6,28 @@ language: python
 matrix:
   include:
     - python: 2.7
-      env: TOXENV=py27-django18-wagtail112
-    - python: 2.7
-      env: TOXENV=py27-django18-wagtail113
-    - python: 2.7
       env: TOXENV=py27-django111-wagtail112
-    - python: 2.7
-      env: TOXENV=py27-django111-wagtail113
 
-    - python: 3.4
-      env: TOXENV=py34-django18-wagtail112
-    - python: 3.4
-      env: TOXENV=py34-django18-wagtail113
-    - python: 3.4
-      env: TOXENV=py34-django111-wagtail112
-    - python: 3.4
-      env: TOXENV=py34-django111-wagtail113
-    - python: 3.4
-      env: TOXENV=py34-django200-wagtail200
-
-
-    - python: 3.5
-      env: TOXENV=py35-django18-wagtail112
-    - python: 3.5
-      env: TOXENV=py35-django18-wagtail113
     - python: 3.5
       env: TOXENV=py35-django111-wagtail112
     - python: 3.5
-      env: TOXENV=py35-django111-wagtail113
+      env: TOXENV=py35-django111-wagtail230
     - python: 3.5
-      env: TOXENV=py35-django200-wagtail200
+      env: TOXENV=py35-django210-wagtail230
+    - python: 3.5
+      env: TOXENV=py35-django220-wagtail250
 
-    - python: 3.6
-      env: TOXENV=py36-django18-wagtail112
-    - python: 3.6
-      env: TOXENV=py36-django18-wagtail113
     - python: 3.6
       env: TOXENV=py36-django111-wagtail112
     - python: 3.6
-      env: TOXENV=py36-django111-wagtail113
+      env: TOXENV=py36-django111-wagtail230
     - python: 3.6
-      env: TOXENV=py36-django200-wagtail200
+      env: TOXENV=py36-django210-wagtail230
+    - python: 3.6
+      env: TOXENV=py36-django220-wagtail250
 
   allow_failures:
-    - python: 3.5
+    - python: 3.6
       env: TOXENV=lint
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@
 sudo: false
 language: python
 
+addons:
+  postgresql: "9.4"
+
 # LOL!
 matrix:
   include:

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',

--- a/src/wagtail_factories/factories.py
+++ b/src/wagtail_factories/factories.py
@@ -1,6 +1,5 @@
 import factory
 from django.utils.text import slugify
-from factory.utils import extract_dict
 
 try:
     from wagtail.wagtailcore.models import Collection, Page, Site

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -12,7 +12,7 @@ CACHES = {
     }
 }
 
-ROOT_URLCONF = 'wagtail.tests.urls'
+ROOT_URLCONF = 'tests.urls'
 
 SECRET_KEY = 'Gx8sMKAtnA69TR9lyAlLuSnozUv3kxdscHkpwEjatZRVQQ0laMY69KL4XPxvr3KY'
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,3 +1,5 @@
+import os
+
 from wagtail import VERSION as WAGTAIL_VERSION
 
 
@@ -17,7 +19,10 @@ SECRET_KEY = 'Gx8sMKAtnA69TR9lyAlLuSnozUv3kxdscHkpwEjatZRVQQ0laMY69KL4XPxvr3KY'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'wagtail_factories',
+        'NAME': os.environ.get('TEST_DB_NAME', 'wagtail_factories'),
+        'USER': os.environ.get('TEST_DB_USER', 'postgres'),
+        'HOST': os.environ.get('TEST_DB_HOST', 'localhost'),
+        'PORT': os.environ.get('TEST_DB_PORT', '5432'),
     },
 }
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,0 +1,10 @@
+from django.conf.urls import url, include
+
+try:
+    from wagtail.wagtailcore import urls as wagtail_urls
+except ImportError:
+    from wagtail.core import urls as wagtail_urls
+
+urlpatterns = []
+
+urlpatterns += [url(r"^", include(wagtail_urls))]

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,22 @@
 [tox]
 envlist =
-    py{27,34,35,36}-django{18,111}-wagtail{112,113}
-    py{34,35,36}-django{111,200}-wagtail200
+    py{27,35,36}-django{111}-wagtail{112}
+    py{35,36}-django{111,210}-wagtail{230}
+    py{35,36}-django{220}-wagtail{250}
     lint
 
 [testenv]
 commands = coverage run --parallel -m pytest {posargs}
 extras = test
 deps =
-    django18: django>=1.8,<1.9
-              djangorestframework>=3.1.3,<3.7
     django111: django>=1.11,<1.12
-    django200: django>=2.0,<2.1
+    django210: django>=2.1,<2.2
+    django220: django>=2.2,<2.3
+    # LTS until November 2019
     wagtail112: wagtail>=1.12,<1.13
-    wagtail113: wagtail>=1.13,<2.0
-    wagtail200: wagtail>=1.13,<2.0
+    # LTS until June 2019
+    wagtail230: wagtail>=2.3,<2.4
+    wagtail250: wagtail>=2.5,<2.6
 
 [testenv:coverage-report]
 basepython = python3.6


### PR DESCRIPTION
Dropped unsupported Python/Django/Wagtail versions
    
Removed:
    
* py3.4
* Django 1.8, 2.0
* Wagtail 1.13, 2.0
    
Added
 
* Django 2.1, 2.2
* Wagtail 2.3, 2.5

Based on support dates from:
https://docs.wagtail.io/en/v2.5.1/releases/upgrading.html
https://www.djangoproject.com/download/

builds on top of #18 
