### PR TITLE
Allow block factory defaults with StreamFieldFactory

### DIFF
--- a/src/wagtail_factories/blocks.py
+++ b/src/wagtail_factories/blocks.py
@@ -22,7 +22,7 @@ class StreamFieldFactory(ParameteredAttribute):
         Syntax:
             <streamfield>__<index>__<block_name>__<key>='foo',
 
-        Syntax to generate blocks with default values
+        Syntax to generate blocks with default factory values:
             <streamfield>__<index>=<block_name>
 
     """

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -123,6 +123,23 @@ def test_custom_page_streamfield_data_complex():
 
 
 @pytest.mark.django_db
+def test_custom_page_streamfield_default_blocks():
+    assert Image.objects.count() == 0
+
+    page = MyTestPageWithStreamFieldFactory(body__0="image", body__1="image")
+    assert Image.objects.count() == 2
+
+    image1, image2 = Image.objects.all()
+
+    assert page.body.stream_data == [
+        ("image", image1), ("image", image2),
+    ]
+
+    content = str(page.body)
+    assert content.count("block-image") == 2
+
+
+@pytest.mark.django_db
 def test_image_chooser_block():
     value = wagtail_factories.ImageChooserBlockFactory()
     image = Image.objects.last()

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -126,6 +126,11 @@ def test_custom_page_streamfield_data_complex():
 def test_custom_page_streamfield_default_blocks():
     assert Image.objects.count() == 0
 
+    with pytest.raises(ValueError) as excinfo:
+        MyTestPageWithStreamFieldFactory(body__0="unknown")
+
+    assert "No factory defined for block `unknown`" in str(excinfo.value)
+
     page = MyTestPageWithStreamFieldFactory(body__0="image", body__1="image")
     assert Image.objects.count() == 2
 


### PR DESCRIPTION
To add blocks to a `StreamField` you need to specify at least one key with a value:
```
<streamfield>__<index>__<block_name>__<key>='foo'
```

This pull request adds the possibility to allow the following format as well:
```
<streamfield>__<index>='<blockname>' 
```
So the factory specified with `blockname` will be called without any parameters